### PR TITLE
Handle vertical metadata columns

### DIFF
--- a/pdf2zh/converter.py
+++ b/pdf2zh/converter.py
@@ -239,7 +239,7 @@ class TranslateConverter(PDFConverterEx):
         VERTICAL_X_THRESHOLD = 2.0
 
         def flush_vertical_chars():
-            nonlocal vertical_chars
+            nonlocal vertical_chars, xt, xt_cls
             if not vertical_chars:
                 return
             layout_chars = sorted(vertical_chars, key=lambda ch: (-ch.y0, ch.x0))
@@ -286,6 +286,8 @@ class TranslateConverter(PDFConverterEx):
                         vertical_spacing=spacing,
                     )
                 )
+                xt = None
+                xt_cls = -1
             vertical_chars = []
 
         def is_vertical_glyph(char: LTChar) -> bool:


### PR DESCRIPTION
Fixes #8

## Summary
- buffer LTChar glyphs with matrix[0]==matrix[3]==0 so vertical columns do not mingle with formula detection
- consolidate those glyphs into Paragraph entries, flipping order via matrix[1]/matrix[2] so strings read left-to-right
- verified that sample_pdf/2304.03442v2.md now shows `## arXiv:2304.03442v2 [cs.HC] 6 Aug 2023` instead of split digits

## Testing
- UV_PROJECT_ENVIRONMENT=.venv uv run pytest test
- UV_PROJECT_ENVIRONMENT=.venv uv run pdf2zh sample_pdf/2304.03442v2.pdf --output sample_pdf --output-format both --no-translate