### PR TITLE
fix: control markdown footnotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ In the following table, we list all advanced options for reference:
 | `-t`                  | [Multi-threads](https://github.com/Byaidu/PDFMathTranslate/blob/main/docs/ADVANCED.md#threads)                | `pdf2zh example.pdf -t 1`                      |
 | `-o`                  | Output dir                                                                                                    | `pdf2zh example.pdf -o output`                 |
 | `--output-format`     | Choose translated artifact: pdf / md / both                                                                   | `pdf2zh example.pdf --output-format both`      |
+| `--markdown-footnotes`| Control Markdown footnotes placement: inline / append / drop                                                 | `pdf2zh example.pdf --output-format md --markdown-footnotes append` |
 | `--no-translate`      | Skip translation and reuse source text (layout debugging)                                                     | `pdf2zh example.pdf --no-translate`            |
 | `-f`, `-c`            | [Exceptions](https://github.com/Byaidu/PDFMathTranslate/blob/main/docs/ADVANCED.md#exceptions)                | `pdf2zh example.pdf -f "(MS.*)"`               |
 | `-cp`                 | Compatibility Mode                                                                                            | `pdf2zh example.pdf --compatible`              |

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ In the following table, we list all advanced options for reference:
 | `-t`                  | [Multi-threads](https://github.com/Byaidu/PDFMathTranslate/blob/main/docs/ADVANCED.md#threads)                | `pdf2zh example.pdf -t 1`                      |
 | `-o`                  | Output dir                                                                                                    | `pdf2zh example.pdf -o output`                 |
 | `--output-format`     | Choose translated artifact: pdf / md / both                                                                   | `pdf2zh example.pdf --output-format both`      |
-| `--markdown-footnotes`| Control Markdown footnotes placement: keep-inline / move-to-end / remove                                      | `pdf2zh example.pdf --output-format md --markdown-footnotes move-to-end` |
+| `--markdown-footnotes`| Control Markdown footnotes placement: move-to-end / remove                                                    | `pdf2zh example.pdf --output-format md --markdown-footnotes move-to-end` |
 | `--no-translate`      | Skip translation and reuse source text (layout debugging)                                                     | `pdf2zh example.pdf --no-translate`            |
 | `-f`, `-c`            | [Exceptions](https://github.com/Byaidu/PDFMathTranslate/blob/main/docs/ADVANCED.md#exceptions)                | `pdf2zh example.pdf -f "(MS.*)"`               |
 | `-cp`                 | Compatibility Mode                                                                                            | `pdf2zh example.pdf --compatible`              |
@@ -296,10 +296,9 @@ pdf2zh document.pdf --output-format md --markdown-footnotes move-to-end
 Options:
 
 - `move-to-end` (default): Move footnotes/page footers to a `### Footnotes` section at the end.
-- `keep-inline`: Keep them at the original positions (may split ABSTRACT text).
 - `remove`: Remove them completely.
 
-Academic papers (ACM/IEEE etc.) usually look cleaner with `move-to-end` or `remove`, because the permission notice on every page no longer breaks the narrative flow.
+Academic papers (ACM/IEEE etc.) usually look cleaner with these options because the permission notice on every page no longer breaks the narrative flow.
 
 #### Self-hosted NVIDIA Riva (beta)
 

--- a/README.md
+++ b/README.md
@@ -299,8 +299,6 @@ Options:
 - `keep-inline`: Keep them at the original positions (may split ABSTRACT text).
 - `remove`: Remove them completely.
 
-> Legacy values `inline`, `append`, and `drop` are still accepted for backward compatibility but will be removed in a future release.
-
 Academic papers (ACM/IEEE etc.) usually look cleaner with `move-to-end` or `remove`, because the permission notice on every page no longer breaks the narrative flow.
 
 #### Self-hosted NVIDIA Riva (beta)

--- a/README.md
+++ b/README.md
@@ -299,7 +299,9 @@ Options:
 - `keep-inline`: Keep them at the original positions (may split ABSTRACT text).
 - `remove`: Remove them completely.
 
-Academic papers (ACM/IEEE etc.) usually look cleaner with `append` or `drop`, because the permission notice on every page no longer breaks the narrative flow.
+> Legacy values `inline`, `append`, and `drop` are still accepted for backward compatibility but will be removed in a future release.
+
+Academic papers (ACM/IEEE etc.) usually look cleaner with `move-to-end` or `remove`, because the permission notice on every page no longer breaks the narrative flow.
 
 #### Self-hosted NVIDIA Riva (beta)
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ In the following table, we list all advanced options for reference:
 | `-t`                  | [Multi-threads](https://github.com/Byaidu/PDFMathTranslate/blob/main/docs/ADVANCED.md#threads)                | `pdf2zh example.pdf -t 1`                      |
 | `-o`                  | Output dir                                                                                                    | `pdf2zh example.pdf -o output`                 |
 | `--output-format`     | Choose translated artifact: pdf / md / both                                                                   | `pdf2zh example.pdf --output-format both`      |
-| `--markdown-footnotes`| Control Markdown footnotes placement: move-to-end / remove                                                    | `pdf2zh example.pdf --output-format md --markdown-footnotes move-to-end` |
+| `--markdown-footnotes`| Control Markdown footnotes placement: keep / drop                                                             | `pdf2zh example.pdf --output-format md --markdown-footnotes keep` |
 | `--no-translate`      | Skip translation and reuse source text (layout debugging)                                                     | `pdf2zh example.pdf --no-translate`            |
 | `-f`, `-c`            | [Exceptions](https://github.com/Byaidu/PDFMathTranslate/blob/main/docs/ADVANCED.md#exceptions)                | `pdf2zh example.pdf -f "(MS.*)"`               |
 | `-cp`                 | Compatibility Mode                                                                                            | `pdf2zh example.pdf --compatible`              |
@@ -290,13 +290,13 @@ For detailed explanations, please refer to our document about [Advanced Usage](.
 When converting PDFs to Markdown, page-level footnotes and copyright notices often interrupt paragraphs. Control their placement via:
 
 ```bash
-pdf2zh document.pdf --output-format md --markdown-footnotes move-to-end
+pdf2zh document.pdf --output-format md --markdown-footnotes keep
 ```
 
 Options:
 
-- `move-to-end` (default): Move footnotes/page footers to a `### Footnotes` section at the end.
-- `remove`: Remove them completely.
+- `keep` (default): Keep footnotes by moving them to a `### Footnotes` section at the end.
+- `drop`: Drop footnotes completely.
 
 Academic papers (ACM/IEEE etc.) usually look cleaner with these options because the permission notice on every page no longer breaks the narrative flow.
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ In the following table, we list all advanced options for reference:
 | `-t`                  | [Multi-threads](https://github.com/Byaidu/PDFMathTranslate/blob/main/docs/ADVANCED.md#threads)                | `pdf2zh example.pdf -t 1`                      |
 | `-o`                  | Output dir                                                                                                    | `pdf2zh example.pdf -o output`                 |
 | `--output-format`     | Choose translated artifact: pdf / md / both                                                                   | `pdf2zh example.pdf --output-format both`      |
-| `--markdown-footnotes`| Control Markdown footnotes placement: inline / append / drop                                                 | `pdf2zh example.pdf --output-format md --markdown-footnotes append` |
+| `--markdown-footnotes`| Control Markdown footnotes placement: keep-inline / move-to-end / remove                                      | `pdf2zh example.pdf --output-format md --markdown-footnotes move-to-end` |
 | `--no-translate`      | Skip translation and reuse source text (layout debugging)                                                     | `pdf2zh example.pdf --no-translate`            |
 | `-f`, `-c`            | [Exceptions](https://github.com/Byaidu/PDFMathTranslate/blob/main/docs/ADVANCED.md#exceptions)                | `pdf2zh example.pdf -f "(MS.*)"`               |
 | `-cp`                 | Compatibility Mode                                                                                            | `pdf2zh example.pdf --compatible`              |
@@ -284,6 +284,22 @@ In the following table, we list all advanced options for reference:
 | `--sse`               | Enable MCP SSE mode                                                                                           | `pdf2zh --mcp --sse`                           |
 
 For detailed explanations, please refer to our document about [Advanced Usage](./docs/ADVANCED.md) for a full list of each option.
+
+#### Markdown Footnote Handling
+
+When converting PDFs to Markdown, page-level footnotes and copyright notices often interrupt paragraphs. Control their placement via:
+
+```bash
+pdf2zh document.pdf --output-format md --markdown-footnotes move-to-end
+```
+
+Options:
+
+- `move-to-end` (default): Move footnotes/page footers to a `### Footnotes` section at the end.
+- `keep-inline`: Keep them at the original positions (may split ABSTRACT text).
+- `remove`: Remove them completely.
+
+Academic papers (ACM/IEEE etc.) usually look cleaner with `append` or `drop`, because the permission notice on every page no longer breaks the narrative flow.
 
 #### Self-hosted NVIDIA Riva (beta)
 

--- a/docs/README_ja-JP.md
+++ b/docs/README_ja-JP.md
@@ -203,8 +203,6 @@ pdf2zh document.pdf --output-format md --markdown-footnotes move-to-end
 - `keep-inline`: 元の位置に残す（ABSTRACTが途中で途切れる可能性あり）
 - `remove`: 脚注を完全に削除
 
-> 旧キーワード `inline` / `append` / `drop` も当面は互換目的で受け付けますが、将来的に削除予定です。
-
 ACM/IEEE形式の論文などでは `move-to-end` もしくは `remove` を使うことで、各ページの許諾文が本文に割り込まず読みやすくなります。
 
 <h3 id="partial">全文または部分的なドキュメント翻訳</h3>

--- a/docs/README_ja-JP.md
+++ b/docs/README_ja-JP.md
@@ -179,6 +179,8 @@ Python環境を事前にインストールする必要はありません
 | `-s`  | [翻訳サービス](#services) |  `pdf2zh example.pdf -s deepl` |
 | `-t`  | [マルチスレッド](#threads) | `pdf2zh example.pdf -t 1` |
 | `-o`  | 出力ディレクトリ | `pdf2zh example.pdf -o output` |
+| `--output-format` | 生成するフォーマット（pdf / md / both） | `pdf2zh example.pdf --output-format both` |
+| `--markdown-footnotes` | Markdown脚注/フッターの扱い（inline / append / drop） | `pdf2zh example.pdf --output-format md --markdown-footnotes append` |
 | `-f`, `-c` | [例外](#exceptions) | `pdf2zh example.pdf -f "(MS.*)"` |
 | `--share` | [gradio公開リンクを取得] | `pdf2zh -i --share` |
 | `--authorized` | [[ウェブ認証とカスタム認証ページの追加](https://github.com/Byaidu/PDFMathTranslate/blob/main/docs/ADVANCED.)] | `pdf2zh -i --authorized users.txt [auth.html]` |

--- a/docs/README_ja-JP.md
+++ b/docs/README_ja-JP.md
@@ -180,7 +180,7 @@ Python環境を事前にインストールする必要はありません
 | `-t`  | [マルチスレッド](#threads) | `pdf2zh example.pdf -t 1` |
 | `-o`  | 出力ディレクトリ | `pdf2zh example.pdf -o output` |
 | `--output-format` | 生成するフォーマット（pdf / md / both） | `pdf2zh example.pdf --output-format both` |
-| `--markdown-footnotes` | Markdown脚注/フッターの扱い（keep-inline / move-to-end / remove） | `pdf2zh example.pdf --output-format md --markdown-footnotes move-to-end` |
+| `--markdown-footnotes` | Markdown脚注/フッターの扱い（move-to-end / remove） | `pdf2zh example.pdf --output-format md --markdown-footnotes move-to-end` |
 | `-f`, `-c` | [例外](#exceptions) | `pdf2zh example.pdf -f "(MS.*)"` |
 | `--share` | [gradio公開リンクを取得] | `pdf2zh -i --share` |
 | `--authorized` | [[ウェブ認証とカスタム認証ページの追加](https://github.com/Byaidu/PDFMathTranslate/blob/main/docs/ADVANCED.)] | `pdf2zh -i --authorized users.txt [auth.html]` |
@@ -200,10 +200,9 @@ pdf2zh document.pdf --output-format md --markdown-footnotes move-to-end
 ```
 
 - `move-to-end`（デフォルト）: 脚注/フッターを末尾の `### Footnotes` セクションにまとめる
-- `keep-inline`: 元の位置に残す（ABSTRACTが途中で途切れる可能性あり）
 - `remove`: 脚注を完全に削除
 
-ACM/IEEE形式の論文などでは `move-to-end` もしくは `remove` を使うことで、各ページの許諾文が本文に割り込まず読みやすくなります。
+ACM/IEEE形式の論文などでは、これらのオプションにより各ページの許諾文が本文に割り込まず読みやすくなります。
 
 <h3 id="partial">全文または部分的なドキュメント翻訳</h3>
 

--- a/docs/README_ja-JP.md
+++ b/docs/README_ja-JP.md
@@ -180,7 +180,7 @@ Python環境を事前にインストールする必要はありません
 | `-t`  | [マルチスレッド](#threads) | `pdf2zh example.pdf -t 1` |
 | `-o`  | 出力ディレクトリ | `pdf2zh example.pdf -o output` |
 | `--output-format` | 生成するフォーマット（pdf / md / both） | `pdf2zh example.pdf --output-format both` |
-| `--markdown-footnotes` | Markdown脚注/フッターの扱い（move-to-end / remove） | `pdf2zh example.pdf --output-format md --markdown-footnotes move-to-end` |
+| `--markdown-footnotes` | Markdown脚注/フッターの扱い（keep / drop） | `pdf2zh example.pdf --output-format md --markdown-footnotes keep` |
 | `-f`, `-c` | [例外](#exceptions) | `pdf2zh example.pdf -f "(MS.*)"` |
 | `--share` | [gradio公開リンクを取得] | `pdf2zh -i --share` |
 | `--authorized` | [[ウェブ認証とカスタム認証ページの追加](https://github.com/Byaidu/PDFMathTranslate/blob/main/docs/ADVANCED.)] | `pdf2zh -i --authorized users.txt [auth.html]` |
@@ -196,11 +196,11 @@ Python環境を事前にインストールする必要はありません
 PDFをMarkdownに変換する際、ページ下部の脚注や著作権表記が本文を分断することがあります。以下のオプションで配置方法を制御できます。
 
 ```bash
-pdf2zh document.pdf --output-format md --markdown-footnotes move-to-end
+pdf2zh document.pdf --output-format md --markdown-footnotes keep
 ```
 
-- `move-to-end`（デフォルト）: 脚注/フッターを末尾の `### Footnotes` セクションにまとめる
-- `remove`: 脚注を完全に削除
+- `keep`（デフォルト）: 脚注を保持し、末尾の `### Footnotes` セクションにまとめる
+- `drop`: 脚注を完全に破棄
 
 ACM/IEEE形式の論文などでは、これらのオプションにより各ページの許諾文が本文に割り込まず読みやすくなります。
 

--- a/docs/README_ja-JP.md
+++ b/docs/README_ja-JP.md
@@ -203,7 +203,9 @@ pdf2zh document.pdf --output-format md --markdown-footnotes move-to-end
 - `keep-inline`: 元の位置に残す（ABSTRACTが途中で途切れる可能性あり）
 - `remove`: 脚注を完全に削除
 
-ACM/IEEE形式の論文などでは `append` もしくは `drop` を使うことで、各ページの許諾文が本文に割り込まず読みやすくなります。
+> 旧キーワード `inline` / `append` / `drop` も当面は互換目的で受け付けますが、将来的に削除予定です。
+
+ACM/IEEE形式の論文などでは `move-to-end` もしくは `remove` を使うことで、各ページの許諾文が本文に割り込まず読みやすくなります。
 
 <h3 id="partial">全文または部分的なドキュメント翻訳</h3>
 

--- a/docs/README_ja-JP.md
+++ b/docs/README_ja-JP.md
@@ -180,7 +180,7 @@ Python環境を事前にインストールする必要はありません
 | `-t`  | [マルチスレッド](#threads) | `pdf2zh example.pdf -t 1` |
 | `-o`  | 出力ディレクトリ | `pdf2zh example.pdf -o output` |
 | `--output-format` | 生成するフォーマット（pdf / md / both） | `pdf2zh example.pdf --output-format both` |
-| `--markdown-footnotes` | Markdown脚注/フッターの扱い（inline / append / drop） | `pdf2zh example.pdf --output-format md --markdown-footnotes append` |
+| `--markdown-footnotes` | Markdown脚注/フッターの扱い（keep-inline / move-to-end / remove） | `pdf2zh example.pdf --output-format md --markdown-footnotes move-to-end` |
 | `-f`, `-c` | [例外](#exceptions) | `pdf2zh example.pdf -f "(MS.*)"` |
 | `--share` | [gradio公開リンクを取得] | `pdf2zh -i --share` |
 | `--authorized` | [[ウェブ認証とカスタム認証ページの追加](https://github.com/Byaidu/PDFMathTranslate/blob/main/docs/ADVANCED.)] | `pdf2zh -i --authorized users.txt [auth.html]` |
@@ -190,6 +190,20 @@ Python環境を事前にインストールする必要はありません
 | `--dir` | [batch translate] | `pdf2zh --dir /path/to/translate/` |
 | `--config` | [configuration file](https://github.com/Byaidu/PDFMathTranslate/blob/main/docs/ADVANCED.md#cofig) | `pdf2zh --config /path/to/config/config.json` |
 | `--serverport` | [custom gradio server port] | `pdf2zh --serverport 7860` |
+
+#### Markdown脚注の制御
+
+PDFをMarkdownに変換する際、ページ下部の脚注や著作権表記が本文を分断することがあります。以下のオプションで配置方法を制御できます。
+
+```bash
+pdf2zh document.pdf --output-format md --markdown-footnotes move-to-end
+```
+
+- `move-to-end`（デフォルト）: 脚注/フッターを末尾の `### Footnotes` セクションにまとめる
+- `keep-inline`: 元の位置に残す（ABSTRACTが途中で途切れる可能性あり）
+- `remove`: 脚注を完全に削除
+
+ACM/IEEE形式の論文などでは `append` もしくは `drop` を使うことで、各ページの許諾文が本文に割り込まず読みやすくなります。
 
 <h3 id="partial">全文または部分的なドキュメント翻訳</h3>
 

--- a/pdf2zh/high_level.py
+++ b/pdf2zh/high_level.py
@@ -25,7 +25,7 @@ from pymupdf import Document, Font
 from pdf2zh.converter import TranslateConverter
 from pdf2zh.doclayout import OnnxModel
 from pdf2zh.pdfinterp import PDFPageInterpreterEx
-from pdf2zh.markdown import export_markdown
+from pdf2zh.markdown import export_markdown, FOOTNOTE_APPEND
 
 from pdf2zh.config import ConfigManager
 from babeldoc.assets.assets import get_font_and_metadata
@@ -319,6 +319,7 @@ def translate(
     skip_subset_fonts: bool = False,
     ignore_cache: bool = False,
     output_format: str = "pdf",
+    markdown_footnotes: str = FOOTNOTE_APPEND,
     **kwarg: Any,
 ):
     if not files:
@@ -418,6 +419,7 @@ def translate(
                     output_dir,
                     filename,
                     reference_doc=reference_doc,
+                    markdown_footnotes=markdown_footnotes,
                 )
             finally:
                 doc_for_md.close()

--- a/pdf2zh/high_level.py
+++ b/pdf2zh/high_level.py
@@ -25,7 +25,7 @@ from pymupdf import Document, Font
 from pdf2zh.converter import TranslateConverter
 from pdf2zh.doclayout import OnnxModel
 from pdf2zh.pdfinterp import PDFPageInterpreterEx
-from pdf2zh.markdown import export_markdown, FOOTNOTE_APPEND
+from pdf2zh.markdown import export_markdown, FOOTNOTE_MOVE_TO_END
 
 from pdf2zh.config import ConfigManager
 from babeldoc.assets.assets import get_font_and_metadata
@@ -319,7 +319,7 @@ def translate(
     skip_subset_fonts: bool = False,
     ignore_cache: bool = False,
     output_format: str = "pdf",
-    markdown_footnotes: str = FOOTNOTE_APPEND,
+    markdown_footnotes: str = FOOTNOTE_MOVE_TO_END,
     **kwarg: Any,
 ):
     if not files:

--- a/pdf2zh/high_level.py
+++ b/pdf2zh/high_level.py
@@ -25,7 +25,7 @@ from pymupdf import Document, Font
 from pdf2zh.converter import TranslateConverter
 from pdf2zh.doclayout import OnnxModel
 from pdf2zh.pdfinterp import PDFPageInterpreterEx
-from pdf2zh.markdown import export_markdown, FOOTNOTE_MOVE_TO_END
+from pdf2zh.markdown import export_markdown, FOOTNOTE_KEEP
 
 from pdf2zh.config import ConfigManager
 from babeldoc.assets.assets import get_font_and_metadata
@@ -319,7 +319,7 @@ def translate(
     skip_subset_fonts: bool = False,
     ignore_cache: bool = False,
     output_format: str = "pdf",
-    markdown_footnotes: str = FOOTNOTE_MOVE_TO_END,
+    markdown_footnotes: str = FOOTNOTE_KEEP,
     **kwarg: Any,
 ):
     if not files:

--- a/pdf2zh/markdown.py
+++ b/pdf2zh/markdown.py
@@ -28,6 +28,8 @@ FOOTNOTE_MODES = {
     FOOTNOTE_MOVE_TO_END,
     FOOTNOTE_REMOVE,
 }
+
+
 def _normalize_footnote_mode(value: Optional[str]) -> str:
     """Map user-provided footnote flag to canonical token."""
     if value is None:
@@ -68,8 +70,8 @@ def _render_markdown_document(
         collected = _extract_structural_footnotes(
             parsed_doc,
             footnote_mode,
-        collect_footnotes,
-    )
+            collect_footnotes,
+        )
     markdown_text = parsed_doc.to_markdown(
         header=True,
         footer=(footnote_mode == FOOTNOTE_KEEP_INLINE),

--- a/pdf2zh/markdown.py
+++ b/pdf2zh/markdown.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -9,7 +8,6 @@ import os
 import re
 
 import pymupdf
-import pymupdf4llm
 from pymupdf4llm import parse_document
 from pymupdf4llm.helpers import document_layout as doc_layout
 

--- a/pdf2zh/markdown.py
+++ b/pdf2zh/markdown.py
@@ -28,22 +28,14 @@ FOOTNOTE_MODES = {
     FOOTNOTE_MOVE_TO_END,
     FOOTNOTE_REMOVE,
 }
-FOOTNOTE_LEGACY_ALIASES = {
-    "inline": FOOTNOTE_KEEP_INLINE,
-    "append": FOOTNOTE_MOVE_TO_END,
-    "drop": FOOTNOTE_REMOVE,
-}
-
-
 def _normalize_footnote_mode(value: Optional[str]) -> str:
     """Map user-provided footnote flag to canonical token."""
     if value is None:
         return FOOTNOTE_MOVE_TO_END
     token = str(value).strip().lower()
-    canonical = FOOTNOTE_LEGACY_ALIASES.get(token, token)
-    if canonical not in FOOTNOTE_MODES:
+    if token not in FOOTNOTE_MODES:
         raise ValueError(f"Invalid markdown footnote mode '{value}'.")
-    return canonical
+    return token
 
 
 @dataclass

--- a/pdf2zh/pdf2zh.py
+++ b/pdf2zh/pdf2zh.py
@@ -107,16 +107,9 @@ def create_parser() -> argparse.ArgumentParser:
     )
     parse_params.add_argument(
         "--markdown-footnotes",
-        choices=[
-            "keep-inline",
-            "move-to-end",
-            "remove",
-            "inline",
-            "append",
-            "drop",
-        ],
+        choices=["keep-inline", "move-to-end", "remove"],
         default="move-to-end",
-        help="Control how Markdown footnotes/page footers are handled (legacy: inline/append/drop).",
+        help="Control how Markdown footnotes/page footers are handled.",
     )
     parse_params.add_argument(
         "--no-translate",

--- a/pdf2zh/pdf2zh.py
+++ b/pdf2zh/pdf2zh.py
@@ -107,9 +107,10 @@ def create_parser() -> argparse.ArgumentParser:
     )
     parse_params.add_argument(
         "--markdown-footnotes",
-        choices=["keep-inline", "move-to-end", "remove"],
+        choices=["move-to-end", "remove"],
         default="move-to-end",
-        help="Control how Markdown footnotes/page footers are handled.",
+        help="Control how Markdown footnotes/page footers are handled: "
+        "move-to-end (collect at document end) or remove (discard).",
     )
     parse_params.add_argument(
         "--no-translate",

--- a/pdf2zh/pdf2zh.py
+++ b/pdf2zh/pdf2zh.py
@@ -106,6 +106,12 @@ def create_parser() -> argparse.ArgumentParser:
         help="Select translated output format.",
     )
     parse_params.add_argument(
+        "--markdown-footnotes",
+        choices=["inline", "append", "drop"],
+        default="append",
+        help="Control how footnotes/page footers appear in Markdown output.",
+    )
+    parse_params.add_argument(
         "--no-translate",
         action="store_true",
         help="Skip translation and reuse original text (for layout debugging).",

--- a/pdf2zh/pdf2zh.py
+++ b/pdf2zh/pdf2zh.py
@@ -107,9 +107,16 @@ def create_parser() -> argparse.ArgumentParser:
     )
     parse_params.add_argument(
         "--markdown-footnotes",
-        choices=["keep-inline", "move-to-end", "remove"],
+        choices=[
+            "keep-inline",
+            "move-to-end",
+            "remove",
+            "inline",
+            "append",
+            "drop",
+        ],
         default="move-to-end",
-        help="Control how Markdown footnotes/page footers are handled.",
+        help="Control how Markdown footnotes/page footers are handled (legacy: inline/append/drop).",
     )
     parse_params.add_argument(
         "--no-translate",

--- a/pdf2zh/pdf2zh.py
+++ b/pdf2zh/pdf2zh.py
@@ -107,10 +107,10 @@ def create_parser() -> argparse.ArgumentParser:
     )
     parse_params.add_argument(
         "--markdown-footnotes",
-        choices=["move-to-end", "remove"],
-        default="move-to-end",
+        choices=["keep", "drop"],
+        default="keep",
         help="Control how Markdown footnotes/page footers are handled: "
-        "move-to-end (collect at document end) or remove (discard).",
+        "keep (collect at document end) or drop (discard).",
     )
     parse_params.add_argument(
         "--no-translate",

--- a/pdf2zh/pdf2zh.py
+++ b/pdf2zh/pdf2zh.py
@@ -107,9 +107,9 @@ def create_parser() -> argparse.ArgumentParser:
     )
     parse_params.add_argument(
         "--markdown-footnotes",
-        choices=["inline", "append", "drop"],
-        default="append",
-        help="Control how footnotes/page footers appear in Markdown output.",
+        choices=["keep-inline", "move-to-end", "remove"],
+        default="move-to-end",
+        help="Control how Markdown footnotes/page footers are handled.",
     )
     parse_params.add_argument(
         "--no-translate",

--- a/test/test_markdown.py
+++ b/test/test_markdown.py
@@ -62,43 +62,6 @@ def test_export_markdown_append_mode(tmp_path, monkeypatch):
     assert "note" in content
 
 
-def test_export_markdown_legacy_alias_append(tmp_path, monkeypatch):
-    source_pdf = SOURCE_PDF
-
-    def fake_render(doc, **kwargs):
-        return (
-            "## Heading\ntranslated line\n",
-            [
-                _FootnoteEntry(
-                    page_number=1,
-                    kind="footnote",
-                    markdown="legacy note",
-                )
-            ],
-        )
-
-    monkeypatch.setattr(
-        "pdf2zh.markdown._render_markdown_document",
-        fake_render,
-    )
-
-    doc = pymupdf.open(source_pdf)
-    try:
-        md_path = export_markdown(
-            doc,
-            tmp_path,
-            "legacy-alias",
-            markdown_footnotes="append",
-            write_images=False,
-        )
-    finally:
-        doc.close()
-
-    content = md_path.read_text(encoding="utf-8")
-    assert "legacy note" in content
-    assert "### Footnotes" in content
-
-
 def test_export_markdown_remove_mode(tmp_path, monkeypatch):
     source_pdf = SOURCE_PDF
 

--- a/test/test_markdown.py
+++ b/test/test_markdown.py
@@ -97,36 +97,3 @@ def test_export_markdown_remove_mode(tmp_path, monkeypatch):
     content = md_path.read_text(encoding="utf-8")
     assert "### Footnotes" not in content
     assert "Permission to make digital copies" not in content
-
-
-def test_export_markdown_keep_inline_mode(tmp_path, monkeypatch):
-    source_pdf = SOURCE_PDF
-
-    inline_marker = "Permission to make digital or hard copies"
-
-    def fake_render(doc, **kwargs):
-        return (
-            f"## Heading\n{inline_marker}\ntranslated line\n",
-            [],
-        )
-
-    monkeypatch.setattr(
-        "pdf2zh.markdown._render_markdown_document",
-        fake_render,
-    )
-
-    doc = pymupdf.open(source_pdf)
-    try:
-        md_path = export_markdown(
-            doc,
-            tmp_path,
-            "inline-mode",
-            markdown_footnotes="keep-inline",
-            write_images=False,
-        )
-    finally:
-        doc.close()
-
-    content = md_path.read_text(encoding="utf-8")
-    assert inline_marker in content
-    assert "### Footnotes" not in content

--- a/test/test_markdown.py
+++ b/test/test_markdown.py
@@ -8,7 +8,7 @@ from pdf2zh.markdown import export_markdown, _FootnoteEntry
 SOURCE_PDF = Path("test/file/translate.cli.plain.text.pdf")
 
 
-def test_export_markdown_append_mode(tmp_path, monkeypatch):
+def test_export_markdown_keep_mode(tmp_path, monkeypatch):
     source_pdf = SOURCE_PDF
 
     call_state = {"count": 0}
@@ -62,7 +62,7 @@ def test_export_markdown_append_mode(tmp_path, monkeypatch):
     assert "note" in content
 
 
-def test_export_markdown_remove_mode(tmp_path, monkeypatch):
+def test_export_markdown_drop_mode(tmp_path, monkeypatch):
     source_pdf = SOURCE_PDF
 
     def fake_render(doc, **kwargs):
@@ -88,7 +88,7 @@ def test_export_markdown_remove_mode(tmp_path, monkeypatch):
             doc,
             tmp_path,
             "drop-mode",
-            markdown_footnotes="remove",
+            markdown_footnotes="drop",
             write_images=False,
         )
     finally:

--- a/test/test_markdown.py
+++ b/test/test_markdown.py
@@ -62,6 +62,43 @@ def test_export_markdown_append_mode(tmp_path, monkeypatch):
     assert "note" in content
 
 
+def test_export_markdown_legacy_alias_append(tmp_path, monkeypatch):
+    source_pdf = SOURCE_PDF
+
+    def fake_render(doc, **kwargs):
+        return (
+            "## Heading\ntranslated line\n",
+            [
+                _FootnoteEntry(
+                    page_number=1,
+                    kind="footnote",
+                    markdown="legacy note",
+                )
+            ],
+        )
+
+    monkeypatch.setattr(
+        "pdf2zh.markdown._render_markdown_document",
+        fake_render,
+    )
+
+    doc = pymupdf.open(source_pdf)
+    try:
+        md_path = export_markdown(
+            doc,
+            tmp_path,
+            "legacy-alias",
+            markdown_footnotes="append",
+            write_images=False,
+        )
+    finally:
+        doc.close()
+
+    content = md_path.read_text(encoding="utf-8")
+    assert "legacy note" in content
+    assert "### Footnotes" in content
+
+
 def test_export_markdown_remove_mode(tmp_path, monkeypatch):
     source_pdf = SOURCE_PDF
 

--- a/test/test_markdown.py
+++ b/test/test_markdown.py
@@ -62,7 +62,7 @@ def test_export_markdown_append_mode(tmp_path, monkeypatch):
     assert "note" in content
 
 
-def test_export_markdown_drop_mode(tmp_path, monkeypatch):
+def test_export_markdown_remove_mode(tmp_path, monkeypatch):
     source_pdf = SOURCE_PDF
 
     def fake_render(doc, **kwargs):
@@ -88,7 +88,7 @@ def test_export_markdown_drop_mode(tmp_path, monkeypatch):
             doc,
             tmp_path,
             "drop-mode",
-            markdown_footnotes="drop",
+            markdown_footnotes="remove",
             write_images=False,
         )
     finally:
@@ -99,7 +99,7 @@ def test_export_markdown_drop_mode(tmp_path, monkeypatch):
     assert "Permission to make digital copies" not in content
 
 
-def test_export_markdown_inline_mode(tmp_path, monkeypatch):
+def test_export_markdown_keep_inline_mode(tmp_path, monkeypatch):
     source_pdf = SOURCE_PDF
 
     inline_marker = "Permission to make digital or hard copies"
@@ -121,7 +121,7 @@ def test_export_markdown_inline_mode(tmp_path, monkeypatch):
             doc,
             tmp_path,
             "inline-mode",
-            markdown_footnotes="inline",
+            markdown_footnotes="keep-inline",
             write_images=False,
         )
     finally:


### PR DESCRIPTION
## Summary
- rework markdown export to use parse_document directly so we can remove page-footer / footnote blocks before merging, keeping abstract paragraphs contiguous
- add `--markdown-footnotes` flag (inline/append/drop) that flows through translate/export_markdown and document the option in EN/JA README
- append collected footnotes at the end of markdown (default) and update the markdown unit test to cover the new flow

## Testing
- uv run pytest test/test_markdown.py
